### PR TITLE
Fix Direct Homography model links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,8 +198,8 @@ A special thanks to [Last Row](https://twitter.com/lastrowview), for providing s
 | Model                  | Description                               | Link                                                                        |
 |------------------------|-------------------------------------------|-----------------------------------------------------------------------------|
 | 11_vs_11_selfplay_last | EDG agent                                 | https://storage.googleapis.com/narya-bucket-1/models/11_vs_11_selfplay_last |
-| deep_homo_model.h5     | Direct Homography estimation Architecture | https://storage.googleapis.com/narya-bucket-1/models/deep_homo_model.h5     |
-| deep_homo_model_1.h5   | Direct Homography estimation Weights      | https://storage.googleapis.com/narya-bucket-1/models/deep_homo_model_1.h5   |
+| deep_homo_model.h5     | Direct Homography estimation Weights      | https://storage.googleapis.com/narya-bucket-1/models/deep_homo_model.h5     |
+| deep_homo_model_1.h5   | Direct Homography estimation Architecture | https://storage.googleapis.com/narya-bucket-1/models/deep_homo_model_1.h5   |
 | keypoint_detector.h5   | Keypoints detection Weights               | https://storage.googleapis.com/narya-bucket-1/models/keypoint_detector.h5   |
 | player_reid.pth        | Player Embedding Weights                  | https://storage.googleapis.com/narya-bucket-1/models/player_reid.pth        |
 | player_tracker.params  | Player & Ball detection Weights           | https://storage.googleapis.com/narya-bucket-1/models/player_tracker.params  |


### PR DESCRIPTION
Links to direct homography estimation weights and architecture were swapped in README.

In [colab notebook] weights for `DirectHomographyModel` are downloaded from this following link:

```
WEIGHTS_PATH = (
    "https://storage.googleapis.com/narya-bucket-1/models/deep_homo_model.h5"
)
```

However, in README this link was described as `Direct Homography estimation Architecture`. 

I've tested weights from link `storage.googleapis.com/narya-bucket-1/models/deep_homo_model_1.h5` and it appears weights are random, so it's only architecture.

Test on `deep_homo_model_1.h5`

![image](https://user-images.githubusercontent.com/3882385/107526368-11b28a00-6bb8-11eb-8fab-85f30472bfe9.png)

Test on `deep_homo_model.h5`

![image](https://user-images.githubusercontent.com/3882385/107526638-56d6bc00-6bb8-11eb-942b-7421250cc1a1.png)

[colab notebook]: https://colab.research.google.com/drive/1VC3yd_M4va86N0q9NsYT0ajhCZ-k1sBO?usp=sharing